### PR TITLE
feat: Add SkipDelay to delay skipping a segment

### DIFF
--- a/docs/castsponsorskip.md
+++ b/docs/castsponsorskip.md
@@ -33,6 +33,7 @@ castsponsorskip [flags]
   -i, --network-interface string     Network interface to use for multicast dns discovery. (default all interfaces)
       --paused-interval duration     Interval to scan paused devices (default 1m0s)
       --playing-interval duration    Interval to scan playing devices (default 500ms)
+      --skip-delay duration          Delay skipping the start of a segment
   -v, --version                      version for castsponsorskip
       --youtube-api-key string       YouTube API key for fallback video identification (required on some Chromecast devices).
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ func Reset() {
 		DiscoverInterval: 5 * time.Minute,
 		PausedInterval:   time.Minute,
 		PlayingInterval:  500 * time.Millisecond,
+		SkipDelay: 0,
 
 		NetworkInterface: "",
 
@@ -41,6 +42,7 @@ type Config struct {
 	DiscoverInterval time.Duration `mapstructure:"discover-interval"`
 	PausedInterval   time.Duration `mapstructure:"paused-interval"`
 	PlayingInterval  time.Duration `mapstructure:"playing-interval"`
+	SkipDelay        time.Duration `mapstructure:"skip-delay"`
 
 	NetworkInterface string `mapstructure:"network-interface"`
 
@@ -58,6 +60,7 @@ func (c *Config) RegisterFlags(cmd *cobra.Command) {
 	c.RegisterDiscoverInterval(cmd)
 	c.RegisterPausedInterval(cmd)
 	c.RegisterPlayingInterval(cmd)
+	c.RegisterSkipDelay(cmd)
 	c.RegisterCategories(cmd)
 	c.RegisterActionTypes(cmd)
 	c.RegisterYouTubeAPIKey(cmd)

--- a/internal/config/intervals.go
+++ b/internal/config/intervals.go
@@ -66,3 +66,16 @@ func (c *Config) RegisterPlayingInterval(cmd *cobra.Command) {
 		}
 	}
 }
+
+func (c *Config) RegisterSkipDelay(cmd *cobra.Command) {
+	key := "skip-delay"
+	cmd.PersistentFlags().Duration(key, Default.SkipDelay, "Delay skipping the start of a segment")
+	if err := c.viper.BindPFlag(key, cmd.PersistentFlags().Lookup(key)); err != nil {
+		panic(err)
+	}
+	if err := cmd.RegisterFlagCompletionFunc(key, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"1m", "2m", "5m", "10m", "30m", "1h"}, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+	}); err != nil {
+		panic(err)
+	}
+}

--- a/internal/config/intervals.go
+++ b/internal/config/intervals.go
@@ -74,7 +74,7 @@ func (c *Config) RegisterSkipDelay(cmd *cobra.Command) {
 		panic(err)
 	}
 	if err := cmd.RegisterFlagCompletionFunc(key, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"1m", "2m", "5m", "10m", "30m", "1h"}, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+		return []string{"500ms", "1s", "2s", "3s", "5s", "10s"}, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
 	}); err != nil {
 		panic(err)
 	}

--- a/internal/device/watch.go
+++ b/internal/device/watch.go
@@ -194,7 +194,7 @@ func (d *Device) tick() error {
 		}
 
 		for i, segment := range d.segments {
-			if segment.Segment[0] <= castMedia.CurrentTime && castMedia.CurrentTime < segment.Segment[1]-1 {
+			if (segment.Segment[0] + float32(config.Default.SkipDelay.Seconds())) <= castMedia.CurrentTime && castMedia.CurrentTime < segment.Segment[1]-1 {
 				d.handleSegment(castMedia, castVol, segment, i)
 			}
 		}


### PR DESCRIPTION
Hi there! Thanks for this awesome project. This is actually my first encounter with SponsorBlock, and I actually like it a lot!

However, I found the sponsor segment timing to be very agressive, to the extent that I'd get thrown off guard when it skips. I don't mind watching the first few seconds of a segue, as it actually even helps me mentally prepare for the skip. 

Therefore, I added the `--skip-delay` flag to delay skipping at the start of a segment. Let me know what you think!
